### PR TITLE
Resolve canonical_name to support "localhost" on windows

### DIFF
--- a/include/async_mqtt5/impl/endpoints.hpp
+++ b/include/async_mqtt5/impl/endpoints.hpp
@@ -88,7 +88,11 @@ public:
 		_owner._connect_timer.expires_after(std::chrono::seconds(5));
 
 		auto timed_resolve = asioex::make_parallel_group(
-			_owner._resolver.async_resolve(ap.host, ap.port, asio::deferred),
+			_owner._resolver.async_resolve(
+				ap.host,
+				ap.port,
+				asio::ip::tcp::resolver::query::canonical_name,
+				asio::deferred),
 			_owner._connect_timer.async_wait(asio::deferred)
 		);
 


### PR DESCRIPTION
Hi Mireo Team,

on Windows async_mqtt5 fails to resolve `localhost`. Changing to a canonical resolver fixes this.